### PR TITLE
Add initial project structure with simple CI integration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: LocalStack TypeDB Extension Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+env:
+  LOCALSTACK_DISABLE_EVENTS: "1"
+  LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}
+
+jobs:
+  integration-tests:
+    name: Run Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup LocalStack and extension
+        run: |
+          docker pull localstack/localstack-pro &
+          docker pull typedb/typedb &
+
+          pip install localstack
+          localstack extensions install "git+https://github.com/whummer/localstack-utils.git#egg=localstack-typedb&subdirectory=localstack-typedb"
+
+          DEBUG=1 localstack start -d
+          localstack wait
+
+      - name: Run integration tests
+        run: |
+          make test
+
+      - name: Print logs
+        if: always()
+        run: |
+          localstack logs
+          localstack stop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Run integration tests
         run: |
+          make install
           make test
 
       - name: Print logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+.venv/
+*.pyc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+VENV_BIN = python3 -m venv
+VENV_DIR ?= .venv
+VENV_ACTIVATE = $(VENV_DIR)/bin/activate
+VENV_RUN = . $(VENV_ACTIVATE)
+
+usage:          ## Shows usage for this Makefile
+	@cat Makefile | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+venv: $(VENV_ACTIVATE)
+
+$(VENV_ACTIVATE):
+	test -d .venv || $(VENV_BIN) .venv
+
+clean:
+	rm -rf .venv/
+
+install: venv   ## Install dependencies
+	$(VENV_RUN); pip install --upgrade localstack pytest requests ruff typedb-driver
+
+format:		    ## Run ruff to format the whole codebase
+	$(VENV_RUN); python -m ruff format .; python -m ruff check --output-format=full --fix .
+
+test:		    ## Run integration tests (requires LocalStack running with the Extension installed)
+	$(VENV_RUN); pytest tests
+
+.PHONY: clean install usage venv format test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# typedb-localstack-demo
-Example of using TypeDB + Localstack
+# TypeDB LocalStack Demo
+
+Sample app that demonstrates how to use TypeDB + LocalStack, to develop and test cloud applications locally.
+
+## Prerequisites
+
+* Docker
+* LocalStack Pro (free trial available [here](https://app.localstack.cloud))
+* `localstack` CLI
+
+## License
+
+The code in this repo is available under the Apache 2.0 license.
+

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,0 +1,69 @@
+import requests
+from localstack.utils.strings import short_uid
+from typedb.driver import TypeDB, Credentials, DriverOptions, TransactionType
+
+
+def test_connect_to_db_via_http_api():
+    host = "typedb.localhost.localstack.cloud:4566"
+
+    # get auth token
+    response = requests.post(
+        f"http://{host}/v1/signin", json={"username": "admin", "password": "password"}
+    )
+    assert response.ok
+    token = response.json()["token"]
+
+    # create database
+    db_name = f"db{short_uid()}"
+    response = requests.post(
+        f"http://{host}/v1/databases/{db_name}",
+        json={},
+        headers={"Authorization": f"bearer {token}"},
+    )
+    assert response.ok
+
+    # list databases
+    response = requests.get(
+        f"http://{host}/v1/databases", headers={"Authorization": f"bearer {token}"}
+    )
+    assert response.ok
+    databases = [db["name"] for db in response.json()["databases"]]
+    assert db_name in databases
+
+    # clean up
+    response = requests.delete(
+        f"http://{host}/v1/databases/{db_name}",
+        headers={"Authorization": f"bearer {token}"},
+    )
+    assert response.ok
+
+
+def test_connect_to_db_via_grpc_endpoint():
+    db_name = "access-management-db"
+    server_host = "typedb.localhost.localstack.cloud:4566"
+
+    driver_cfg = TypeDB.driver(
+        server_host,
+        Credentials("admin", "password"),
+        DriverOptions(is_tls_enabled=False),
+    )
+    with driver_cfg as driver:
+        if driver.databases.contains(db_name):
+            driver.databases.get(db_name).delete()
+        driver.databases.create(db_name)
+
+        with driver.transaction(db_name, TransactionType.SCHEMA) as tx:
+            tx.query("define entity person;").resolve()
+            tx.query("define attribute name, value string; person owns name;").resolve()
+            tx.commit()
+
+        with driver.transaction(db_name, TransactionType.WRITE) as tx:
+            tx.query("insert $p isa person, has name 'Alice';").resolve()
+            tx.query("insert $p isa person, has name 'Bob';").resolve()
+            tx.commit()
+        with driver.transaction(db_name, TransactionType.READ) as tx:
+            results = tx.query(
+                'match $p isa person; fetch {"name": $p.name};'
+            ).resolve()
+            for json in results:
+                print(json)


### PR DESCRIPTION
Add initial project structure with simple CI integration test. 

Note: a Github Actions secret `TEST_LOCALSTACK_AUTH_TOKEN` has been added to this repo, to enable startup of LocalStack and activate the Pro features.